### PR TITLE
Extend interpreter to all cbor types

### DIFF
--- a/src/cbor.erl
+++ b/src/cbor.erl
@@ -17,11 +17,14 @@
 -export([encode/1, encode_hex/1,
          decode/1, decode/2, decode_hex/1, decode_hex/2]).
 
--export_type([tag/0, tagged_value/0, simple_value/0]).
+-export_type([tag/0, value/0, simple_value/0, type/0]).
 
--type tag() :: non_neg_integer().
+-type tag() :: {tag, non_neg_integer()}.
 
--type tagged_value() :: {tag(), term()}.
+-type type() :: unsigned_integer | neg_integer | byte_string
+              | utf8_string | array | map | simple | float | tag().
+
+-type value() :: {type(), term()}.
 
 -type simple_value() :: {simple_value, 0..255}
                       | false | true | null | undefined.


### PR DESCRIPTION
Hey, 

I've been using your library with some success, until now, but have found this (let's call it) limitation I'd like to overcome. I need the library to return the decoded type with the decoded value and I thought of using existent interpreter implementation to all the decoded types, making this library more portable.
Before I continue I'd like to request guidance on whether you think this is acceptable. Thanks.

Also I would like to note that I know that you currently aren't accepting any contribution, however if this PR is accepted it would make the integration a lot easier and please have in mind that I tried to change the least code I could.